### PR TITLE
Fix: Add Google Drive host permissions to enable ZIP downloads

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Gmail Bulk Attachments Downloader",
   "short_name": "Bulk Attach",
   "description": "Download every Gmail attachment with one click while keeping original filenames and formats intact.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Katsopolis",
   "icons": {
     "16": "img/logo_16.png",
@@ -19,7 +19,9 @@
     "https://mail.google.com/",
     "https://inbox.google.com/",
     "https://www.google-analytics.com/",
-    "https://mail-attachment.googleusercontent.com/*"
+    "https://mail-attachment.googleusercontent.com/*",
+    "https://drive.google.com/*",
+    "https://drive.usercontent.google.com/*"
   ],
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
- Added drive.google.com and drive.usercontent.google.com to host_permissions
- This allows the background script to fetch Google Drive attachments without CORS errors
- Fixes the issue where ZIP downloads created empty error.txt files for Drive attachments
- Bumped version to 1.0.5